### PR TITLE
Added basic structure of Explore page

### DIFF
--- a/frontend/beerme/src/App.js
+++ b/frontend/beerme/src/App.js
@@ -1,11 +1,9 @@
 import React from "react";
 import Explore from "./Components/Explore";
-import Header from "./Components/Layout/Header";
 
 function App() {
   return (
     <div className="BeerMe">
-      <Header />
       <Explore />
     </div>
   );

--- a/frontend/beerme/src/Components/Explore.js
+++ b/frontend/beerme/src/Components/Explore.js
@@ -1,27 +1,146 @@
 import React, { Component } from "react";
 import ExploreButton from "./ExploreButton";
-import PropTypes from "prop-types";
+import Header from "./Layout/Header";
 
 export class Explore extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  componentDidMount() {
+    fetch("http://jsonplaceholder.typicode.com/todos")
+      .then(res => res.json())
+      .then(data => {
+        data.forEach(element => {
+          element.selected = false;
+        });
+        this.setState({ contacts: data.slice(0, 20) });
+      })
+      .catch(console.log);
+  }
+
   onPreviousClick = () => {
-    console.log("Previous");
+    console.log("onPreviousClick");
   };
 
-  _renderHeader() {}
+  onNextClick = () => {
+    const selections = this.state.contacts.filter(data => data.selected);
+    console.log(selections);
+  };
+
+  _onCheckboxClick = id => {
+    this.setState({
+      data: this.state.contacts.map(option => {
+        if (option.id === id) {
+          option.selected = !option.selected;
+        }
+        return option;
+      })
+    });
+  };
+
+  _renderHeader() {
+    return <Header />;
+  }
+
+  _renderTopBlurb() {
+    return (
+      <React.Fragment>
+        <h1 style={titleStyle}>Explore</h1>
+        <h5 style={descStyle}>
+          Use our unique beer exploration tool to find new and interesting beers
+          for you!
+        </h5>
+      </React.Fragment>
+    );
+  }
+
+  _renderSelectionBox() {
+    return (
+      <div style={selectionBoxStyle}>
+        {this._renderSelBoxTopText()}
+        {this._renderSelections()}
+      </div>
+    );
+  }
+
+  _renderSelBoxTopText() {
+    return (
+      <div style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+        <h2>Preferred Notes</h2>
+        <h5>This is where the explanation of what a note is in beer lives.</h5>
+      </div>
+    );
+  }
+
+  _renderSelections() {
+    if (this.state.contacts) {
+      return (
+        <React.Fragment>
+          {this.state.contacts.map(data => this._renderChecboxOption(data))}
+        </React.Fragment>
+      );
+    }
+    return null;
+  }
+
+  _renderChecboxOption(data) {
+    return (
+      <div key={data.id}>
+        <input
+          type="checkbox"
+          onClick={this._onCheckboxClick.bind(this, data.id)}
+        />
+        {data.title}
+      </div>
+    );
+  }
+
+  _renderProgressionButtons() {
+    return (
+      <div style={btnsStyle}>
+        <ExploreButton
+          style={{ paddingTop: "10px" }}
+          onClick={this.onPreviousClick}
+          title={"<-- Previous"}
+        />
+        <ExploreButton
+          style={{ paddingTop: "10px" }}
+          onClick={this.onNextClick}
+          title={"Next -->"}
+        />
+      </div>
+    );
+  }
 
   render() {
     return (
       <div>
         {this._renderHeader()}
-        <h1>Explore</h1>
-        <ExploreButton onClick={this.onPreviousClick} title={"<-- Previous"} />
+        <div style={{ marginLeft: "200px", marginRight: "200px" }}>
+          {this._renderTopBlurb()}
+          {this._renderSelectionBox()}
+          {this._renderProgressionButtons()}
+        </div>
       </div>
     );
   }
 }
 
-// Explore.PropTypes = {
+const titleStyle = {};
 
-// };
+const descStyle = {};
+
+const selectionBoxStyle = {
+  justifyContent: "center",
+  alignItems: "center",
+  background: "#F4F4F4"
+};
+
+const btnsStyle = {
+  display: "flex",
+  justifyContent: "space-between"
+};
 
 export default Explore;

--- a/frontend/beerme/src/Components/ExploreButton.js
+++ b/frontend/beerme/src/Components/ExploreButton.js
@@ -5,9 +5,11 @@ import * as Constants from "../Utils/Constants";
 export class ExploreButton extends Component {
   render() {
     return (
-      <button style={btnStyle} onClick={this.props.onClick}>
-        {this.props.title}
-      </button>
+      <div style={this.props.style}>
+        <button style={btnStyle} onClick={this.props.onClick}>
+          {this.props.title}
+        </button>
+      </div>
     );
   }
 }


### PR DESCRIPTION
* Added skeleton code for Explore page.
    * Makes basic API call to `jsonplaceholder.typicode.com/todos` to generate data for the checkboxes. This will be changed to a DB API call at a later date.
    * This includes very basic styling that will be adjusted later once the MVP is complete.

<img width="1792" alt="Screen Shot 2020-02-07 at 2 36 50 PM" src="https://user-images.githubusercontent.com/16504741/74070945-47c29a00-49b7-11ea-8739-359c642cf45c.png">
